### PR TITLE
Dodanie zaokraglania kwot w raportach i rates

### DIFF
--- a/SDA_SmartKantor/SmartKantor_app/DisplayMenu.cpp
+++ b/SDA_SmartKantor/SmartKantor_app/DisplayMenu.cpp
@@ -1,6 +1,7 @@
 #include "DisplayMenu.hpp"
 #include "ConGui/ConGui.h"
 #include "Cashier.hpp"
+#include <sstream>
 
 // definicja konstruktora która przyjmuje referencje do obiektu cashier i przekazuje j¹ do pola klasy
 DisplayMenu::DisplayMenu(Cashier& cashier)
@@ -246,10 +247,16 @@ void DisplayMenu::ratesMenu(std::string& lastDisplayedMessage, Menu& menuRef)
         // do currCodeString wsadzamy poszczególne elementy mapy
         // getCurrencyTarget to nazwa waluty
         // changeEnumToString jest metoda (w Currency.hpp) zamieniajaca enumy (kod waluty) na stringi
-        // BuyPrice jest zamieniana z float na string (std::to_string)
-        // SellPrice jest zamieniana z float na string (std::to_string)
+        // poni¿ej sa zmienne pomocnicze typu stringstream do wyswietlenia tylko 4 miejsc po przecinku
+
+        std::stringstream ssBuyPrice;
+        ssBuyPrice << std::fixed << std::setprecision(4) << element.second.getBuyPrice();
+
+        std::stringstream ssSellPrice;
+        ssSellPrice << std::fixed << std::setprecision(4) << element.second.getSellPrice();
+
         std::string currCodeString = element.second.getCurrencyTarget() + " | " + changeEnumToString(element.first)
-            + " | " + std::to_string(element.second.getBuyPrice()) + " | " + std::to_string(element.second.getSellPrice());
+            + " | " + ssBuyPrice.str() + " | " + ssSellPrice.str();
 
         // j.w ramka i tekst
         ConGui::Box((ConGui::ConsoleWidth / 2) - (currCodeString.length() / 2) - 3, (distanceBetweenText - 1), 

--- a/SDA_SmartKantor/SmartKantor_app/FileManager.cpp
+++ b/SDA_SmartKantor/SmartKantor_app/FileManager.cpp
@@ -1,6 +1,7 @@
 #include "FileManager.hpp"
 #include "TempRatesRetriever.hpp"
 #include <string>
+#include <sstream>
 
 void FileManager::manageFilesReports()
 {
@@ -17,9 +18,13 @@ void FileManager::save(Currency::CurrencyCode currCode, float amount, float valu
         manageFilesReports();
     }
     std::string dtstring = dt;
+    std::stringstream ssAmount;
+    ssAmount << std::fixed << std::setprecision(2) << amount;
+    std::stringstream ssValue;
+    ssValue << std::fixed << std::setprecision(2) << value;
     std::string
-        str = "data transakcji: " + dtstring + "  ilosc: " + std::to_string(amount) +
-        "  wartosc: " + std::to_string(value) + "PLN " + "waluta: " + currCode + " typ transakcji : " + type;
+        str = "data transakcji: " + dtstring + "  ilosc: " + ssAmount.str() +
+        "  wartosc: " + ssValue.str() + "PLN " + "waluta: " + currCode + " typ transakcji : " + type;
     str.erase(std::remove(str.begin(), str.end(), '\n'), str.cend());
     myWriteFile << str << '\n';
     myWriteFile.close();

--- a/SDA_SmartKantor/SmartKantor_app/reports.txt
+++ b/SDA_SmartKantor/SmartKantor_app/reports.txt
@@ -1,4 +1,0 @@
-data transakcji: Sun Nov  6 14:20:16 2022  ilosc: 10.000000  wartosc: 50.900002PLN waluta: USD typ transakcji : kupno
-data transakcji: Sun Nov  6 14:20:22 2022  ilosc: 20.000000  wartosc: 98.000000PLN waluta: USD typ transakcji : sprzedaz
-data transakcji: Sun Nov  6 14:31:01 2022  ilosc: 10.000000  wartosc: 50.900002PLN waluta: USD typ transakcji : kupno
-data transakcji: Sun Nov  6 14:31:06 2022  ilosc: 10.000000  wartosc: 49.099998PLN waluta: CHF typ transakcji : sprzedaz


### PR DESCRIPTION
Zaokraglanie w raportach do 2 miejsc po przecinku, bo w kasie wydajemy kwotę co do groszy.
Zaokrąglanie w rates do 4 miejsc po przecinku (tak jak w kantorach).